### PR TITLE
Remove deprecated jcenter repository

### DIFF
--- a/marklogic/build.gradle
+++ b/marklogic/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 repositories {
   mavenCentral()
-  jcenter()
+  // jcenter() // Removed in Gradle 8
   maven {url "https://developer.marklogic.com/maven2/"}
 }
 


### PR DESCRIPTION
JCenter is read-only and deprecated, and is no longer available in Gradle 8. This seems to run fine without it, so presumably the prerequisites are available elsewhere.

Commented out rather than removed so peopple have a chance to see that this might have changed.

https://blog.gradle.org/jcenter-shutdown for more information