### PR TITLE
Update documentation following repo name change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,32 @@
-# Case Law Public Access Service
+# Find Case Law
 
 [![standard-readme compliant](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
 
 ## Table of Contents
 
 - [Background](#background)
-- [Services](#services)
+- [Parts of the service](#parts-of-the-service)
 - [Architecture](#architecture)
 - [Contributing](#contributing)
 - [License](#license)
 
 ## Background
 
-This is the central repository for the [Case Law Public Access service](https://caselaw.nationalarchives.gov.uk/). It includes [architectural decisions](https://github.com/nationalarchives/ds-caselaw-public-access-service/tree/main/doc/adr),[technical designs](https://github.com/nationalarchives/ds-caselaw-public-access-service/tree/main/doc/arch), and links to individual code repositories for the various component [microservices](doc/adr/0002-use-a-microservice-architecture.md).
+This is the central repository for the [Find Case Law service](https://caselaw.nationalarchives.gov.uk/). It includes [architectural decisions](https://github.com/nationalarchives/ds-find-caselaw-docs/tree/main/doc/adr),[technical designs](https://github.com/nationalarchives/ds-find-caselaw-docs/tree/main/doc/arch), and links to individual code repositories for the various component [microservices](doc/adr/0002-use-a-microservice-architecture.md).
 
-## Services
+## Parts of the service
 
-* [Public Access UI](https://github.com/nationalarchives/ds-caselaw-public-ui/)
-* [Editorial UI](https://github.com/nationalarchives/ds-caselaw-editor-ui/)
+* [Public Access UI](https://github.com/nationalarchives/ds-caselaw-public-ui)
+* [Editorial UI](https://github.com/nationalarchives/ds-caselaw-editor-ui)
 * [Ingester](https://github.com/nationalarchives/ds-caselaw-ingester)
 * [PDF conversion](https://github.com/nationalarchives/ds-caselaw-pdf-conversion)
-* [Marklogic database configuration](https://github.com/nationalarchives/ds-caselaw-public-access-service/tree/main/marklogic)
-* [OpenAPI spec](https://github.com/nationalarchives/ds-caselaw-public-access-service/tree/main/doc/openapi)
+
+### Configuration
+
+For historical reasons, some parts of the service are contained in this repository.
+
+* [Marklogic database configuration](https://github.com/nationalarchives/ds-find-caselaw-docs/tree/main/marklogic)
+* [OpenAPI specification](https://github.com/nationalarchives/ds-find-caselaw-docs/tree/main/doc/openapi)
 
 ### Shared support libraries
 

--- a/marklogic/README.md
+++ b/marklogic/README.md
@@ -26,7 +26,7 @@ The releases are currently manually tagged. Please do not deploy to production w
 there is no auto-deployment of releases, but we are using releases & tags to keep track of what has been deployed to
 production.
 
-To create a versioned release, use Github's [release pricess](https://github.com/nationalarchives/ds-caselaw-public-access-service/releases)
+To create a versioned release, use Github's [release process](https://github.com/nationalarchives/ds-find-caselaw-docs/releases)
 to create a tag and generate release notes.
 
 When deploying to production, check out the tag you want to deploy using (for example) `git checkout tags/v1.0.0`


### PR DESCRIPTION
To increase consistency with other National Archives repositories, this repository has been renamed from `ds-caselaw-public-access-service` to `ds-find-caselaw-docs`.

This PR updates links in documentation.