### PR TITLE
Get name when searching via TDR

### DIFF
--- a/marklogic/src/main/ml-modules/root/judgments/search/search-v2.xqy
+++ b/marklogic/src/main/ml-modules/root/judgments/search/search-v2.xqy
@@ -46,7 +46,7 @@ let $params := map:map()
     => map:with('show_unpublished', $show_unpublished)
     => map:with('only_unpublished', $only_unpublished)
 
-let $query1 := if ($q) then helper:make-q-query($q) else ()
+let $query1 := if ($q and not(helper:is-a-consignment-number($q))) then (helper:make-q-query($q)) else ()
 let $query2 := if ($party) then
     cts:or-query((
         cts:element-word-query(fn:QName('http://docs.oasis-open.org/legaldocml/ns/akn/3.0', 'party'), $party),
@@ -119,8 +119,6 @@ else
 let $scope := if ($order = 'updated') then
     'properties'
 else if ($order = '-updated') then
-    'properties'
-else if (exists($query12)) then
     'properties'
 else
     'documents'

--- a/marklogic/src/main/ml-modules/root/judgments/search/search.xqy
+++ b/marklogic/src/main/ml-modules/root/judgments/search/search.xqy
@@ -46,7 +46,7 @@ let $params := map:map()
     => map:with('show_unpublished', $show_unpublished)
     => map:with('only_unpublished', $only_unpublished)
 
-let $query1 := if ($q) then helper:make-q-query($q) else ()
+let $query1 := if ($q and not(helper:is-a-consignment-number($q))) then (helper:make-q-query($q)) else ()
 let $query2 := if ($party) then
     cts:or-query((
         cts:element-word-query(fn:QName('http://docs.oasis-open.org/legaldocml/ns/akn/3.0', 'party'), $party),
@@ -115,8 +115,6 @@ else
 let $scope := if ($order = 'updated') then
     'properties'
 else if ($order = '-updated') then
-    'properties'
-else if (exists($query12)) then
     'properties'
 else
     'documents'


### PR DESCRIPTION
https://trello.com/c/k4qWwcK3/140

I do not fully understand what is happening here, but I think I understand it better than when I did before.

The crux of the bug is, I think, twofold:

When searching with a TDR- query, it searched for the search query in the selected XML (via `$query1`) and explicitly in the `transfer-consignment-reference` property of the relevant document.

The selected XML (`$scope`, the `<fragment-scope/>`) was the **properties** of the document, not the judgment XML itself, hence the title was missing (because that is part of the judgment XML, not a metadata property).

But: if we change the selected XML to be the document, the search fails, because the search query (`TDR-2022-XML` for example) does not appear within the judgment XML.

So we have to fix it in two places.

This all makes perfect sense... if it wasn't for why it works fine and has titles if `$order` is `updated` and `$scope` is set to `properties`... so I think the above might just be wild speculation.

(The code appears twice, in `search.xqy` and `search-v2.xqy` because we made a breaking change to how `$court` was passed and needed to update it everywhere in a non-breaking way. I believe we can now safely delete `search.xqy` but that feels outside the scope of this PR. I have left an error message in search.xqy on staging to see if we trip it, I can find no references to it in the code. But that's a tomorrow problem.)