### PR TITLE
Tidy README and add explicit CONTRIBUTING documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# Contributing to this repository
+
+This project is not actively seeking external contributions. If you raise an issue or open a pull request, we will do our best to respond to it, but we can’t guarantee that we will fix or merge anything.
+
+If you’re thinking about putting a lot of work into a pull request, and would like to get a better idea of whether we’d consider merging it, we advise that you first open a GitHub issue so that we can talk about it.

--- a/README.md
+++ b/README.md
@@ -9,12 +9,11 @@ This repository is part of the [Find Case Law](https://caselaw.nationalarchives.
 - [Background](#background)
 - [Parts of the service](#parts-of-the-service)
 - [Architecture](#architecture)
-- [Contributing](#contributing)
-- [License](#license)
-
 ## Background
 
-This is the central repository for the [Find Case Law service](https://caselaw.nationalarchives.gov.uk/). It includes [architectural decisions](https://github.com/nationalarchives/ds-find-caselaw-docs/tree/main/doc/adr),[technical designs](https://github.com/nationalarchives/ds-find-caselaw-docs/tree/main/doc/arch), and links to individual code repositories for the various component [microservices](doc/adr/0002-use-a-microservice-architecture.md).
+This is the central repository for the [Find Case Law service](https://caselaw.nationalarchives.gov.uk/). It includes [architectural decisions](https://github.com/nationalarchives/ds-find-caselaw-docs/tree/main/doc/adr), [technical designs](https://github.com/nationalarchives/ds-find-caselaw-docs/tree/main/doc/arch), and links to individual code repositories for the various component [microservices](doc/adr/0002-use-a-microservice-architecture.md).
+
+If you are looking for documentation covering user research, design decisions or accessibility, take a look at the [Wiki](https://github.com/nationalarchives/ds-find-caselaw-docs/wiki).
 
 ## Parts of the service
 
@@ -76,26 +75,3 @@ Services provide data to, or take data from, this system.
 
   ![Deployment Diagram](doc/arch/images/Deployment%20Diagram.png)
 </details>
-
-## Contributing
-
-### Behaviour and safety
-
-We want everybody to be safe when interacting with this project. So,
-anybody raising an issue or opening a pull request is expected to
-follow the Contributor Covenant
-[Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
-
-### What to expect
-
-This project is not actively seeking external contributions. If you raise an
-issue or open a pull request, we will do our best to respond to it, but we
-can’t guarantee that we will fix or merge anything.
-
-If you’re thinking about putting a lot of work into a pull request, and would
-like to get a better idea of whether we’d consider merging it, we advise that
-you first open a GitHub issue so that we can talk about it.
-
-## License
-
-[MIT](LICENSE.md) © Crown Copyright (The National Archives)


### PR DESCRIPTION
This cleans up the README, fixes a couple of typographical glitches, and links to the wiki for non-technical documentation. It also moves contributing data into its own file, so GitHub can pick it up and flag it to people engaging with the project for the first time.

This _explicitly_ breaks the Readme Standard, but since that hasn't been maintained for a few years and seems quite heavy-handed I personally prefer things being more usable than blindly following a spec.