### PR TITLE
Schedule Renovate to only automerge between 10-4 on weekdays

### DIFF
--- a/default.json
+++ b/default.json
@@ -11,6 +11,7 @@
     ":dependencyDashboard",
     ":enablePreCommit"
   ],
+  "timezone": "Europe/London",
   "platformAutomerge": true,
   "minimumReleaseAge": "2 days",
   "packageRules": [

--- a/default.json
+++ b/default.json
@@ -13,6 +13,10 @@
   ],
   "timezone": "Europe/London",
   "platformAutomerge": true,
+  "automergeSchedule": [
+    "after 10am every weekday",
+    "before 4pm every weekday"
+  ],
   "minimumReleaseAge": "2 days",
   "packageRules": [
     {


### PR DESCRIPTION
This keeps noise outside working hours to a minimum.