### PR TITLE
Add lockfile maintenance to Renovate configuration

### DIFF
--- a/default.json
+++ b/default.json
@@ -8,6 +8,7 @@
     ":automergePr",
     ":automergeRequireAllStatusChecks",
     ":automergeTesters",
+    ":lockFileMaintenance",
     ":dependencyDashboard",
     ":enablePreCommit"
   ],


### PR DESCRIPTION
This will periodically (weekly, on a Monday morning) perform updates on lockfiles to make sure that dependencies are running the latest versions within the constraints given.