### PR TITLE
[FCL-179] Update Renovate config to label vulnerabilities

### DIFF
--- a/default.json
+++ b/default.json
@@ -26,5 +26,8 @@
       "groupName": "boto packages"
     }
   ],
-  "labels": ["dependencies"]
+  "labels": ["dependencies"],
+  "vulnerabilityAlerts": {
+    "addLabels": ["security"]
+  }
 }


### PR DESCRIPTION
This will now label PRs which address known vulnerabilities with "security", giving them greater visibility in PR lists.

Since this configuration is used across all repos, no further changes are needed.