### PR TITLE
FCL-631 | add front-end ADRS

### DIFF
--- a/doc/adr/0022-tna-frontend-colours-override.md
+++ b/doc/adr/0022-tna-frontend-colours-override.md
@@ -1,0 +1,42 @@
+# 22. TNA Front-End Colour Overrides
+
+**Date:** 2025-02-07
+**Status:** Accepted
+
+## Context
+
+### Background
+
+The application uses colour values provided by the TNA front-end library. However, the available colours do not fully align with the requirements of Find Case Law.
+
+### Problem
+
+The existing TNA colour palette does not provide appropriate mappings for all features and areas within Find Case Law, resulting in inconsistent or suboptimal visual presentation.
+
+### Goals
+
+Establish a mechanism to define colours that align with the requirements of Find Case Law while maintaining compatibility with the TNA front-end library.
+
+## Options Considered
+
+1. Use an alternative colour scheme instead of the TNA colours.
+2. Introduce additional colours outside the TNA scheme and combine them as needed.
+3. Override specific TNA colours to better align with the Find Case Law design.
+
+## Decision
+
+### Solution
+
+Override specific TNA colour values by importing the SCSS variable map into the application and redefining the relevant colours.
+
+### Justification
+
+- Maintains alignment with the colour choices defined in the colour variable ADR.
+- Provides flexibility to adjust colour values as needed for Find Case Law.
+- Reduces the need for a completely independent colour scheme.
+
+## Consequences
+
+- The application will diverge from the standard TNA colour scheme.
+- Changes to the TNA colour variable map (e.g., naming conventions or format) will require updates to the implementation.
+- The modified colours may not fully adhere to the accessibility standards of the TNA scheme.

--- a/doc/adr/0023-style-lint.md
+++ b/doc/adr/0023-style-lint.md
@@ -1,0 +1,47 @@
+# 23. StyleLint Configuration
+
+**Date:** 2025-02-07
+**Status:** Accepted
+
+## Context
+
+### Background
+
+A basic configuration of StyleLint is currently enforced through a pre-commit hook. However, this configuration is minimal.
+
+### Problem
+
+The existing StyleLint setup lacks comprehensive rules to ensure consistent and standardised CSS. This results in potential inconsistencies that require manual intervention during development and code reviews.
+
+### Goals
+
+Implement an automated style linting configuration that enforces consistent and standardised CSS while minimising manual effort during composition and review.
+
+## Options Considered
+
+1. Use the `stylelint-selector-bem` library to enforce BEM class naming.
+2. Use the `stylelint-clean-order` library to enforce a structured CSS property order.
+3. Use `stylelint-standard-css` to enforce general CSS best practices.
+4. Define a custom selector class pattern for BEM class naming.
+5. Maintain a per-repository StyleLint configuration file.
+6. Use a shared StyleLint configuration file across repositories, with the option for per-repository extensions.
+
+## Decision
+
+### Solution
+
+- Use the `stylelint-clean-order` and `stylelint-standard-css` libraries for property ordering and general CSS best practices.
+- Define a custom selector class pattern for BEM class naming.
+- Maintain a shared StyleLint configuration file that can be extended by individual repositories as needed.
+
+### Justification
+
+- The `stylelint-clean-order` and `stylelint-standard-css` libraries provide effective linting out of the box, reducing the need to define custom rules.
+- The `stylelint-selector-bem` library requires extensive configuration, making it equivalent to defining custom rules manually.
+- A shared StyleLint configuration ensures consistency across repositories while allowing flexibility where necessary.
+
+## Consequences
+
+- The BEM selector function must be maintained internally. However, as the BEM methodology is stable, changes should be infrequent.
+- Allowing repositories to extend the shared configuration introduces the possibility of slight deviations in CSS conventions across projects.
+- Any updates to the StyleLint configuration will require corresponding updates in downstream repositories, including adjustments to any affected CSS.

--- a/doc/adr/0024-usage-of-gov-uk-front-end.md
+++ b/doc/adr/0024-usage-of-gov-uk-front-end.md
@@ -1,0 +1,49 @@
+# 24. Usage of GOV.UK Front-End
+
+**Date:** 2025-02-07
+**Status:** Accepted
+
+## Context
+
+### Background
+
+The Find Case Law website is a public government service. The GOV.UK Frontend library provides pre-built, accessible components designed for government services.
+
+### Problem
+
+To develop new features efficiently, the project requires a component library that is accessible, follows industry standards, and minimises maintenance effort. Building all components from scratch would slow development and increase maintenance overhead.
+
+### Goals
+
+- Ensure accessibility in new features.
+- Accelerate development.
+- Maintain industry-standard component behavior.
+- Minimise code maintenance.
+
+## Options Considered
+
+1. Build a custom component library from scratch.
+2. Use the GOV.UK Frontend library as a dependency and override styling where necessary.
+3. Fork the GOV.UK component library and modify core styles directly.
+4. Use a third-party component library and style it to match Find Case Law branding.
+
+## Decision
+
+### Solution
+
+- Add the GOV.UK Frontend library as a dependency.
+- Override styles that do not align with Find Case Law where necessary.
+- Keep CSS overrides as decoupled from the application as possible.
+- Wrap GOV.UK components in Find Case Law-specific components to decouple usage from direct dependency on GOV.UK markup.
+
+### Justification
+
+- Using GOV.UK Frontend as a dependency ensures compatibility with upstream updates and feature additions.
+- Overriding styles selectively minimises breaking changes and prevents tight coupling between Find Case Law styling and GOV.UK components.
+- Abstracting GOV.UK components into Find Case Law equivalents allows for future changes with minimal impact when updating the library.
+
+## Consequences
+
+- New features can be built efficiently without unnecessary development overhead.
+- Components remain accessible and adhere to government service standards.
+- Decoupling from direct GOV.UK component usage reduces maintenance effort and limits the impact of upstream changes.

--- a/doc/adr/0025-usage-of-home-office-front-end.md
+++ b/doc/adr/0025-usage-of-home-office-front-end.md
@@ -1,0 +1,46 @@
+# 25. Usage of Home Office Front-End
+
+**Date:** 2025-02-07
+**Status:** Accepted
+
+## Context
+
+### Background
+
+The application currently uses multiple alert components from different libraries, leading to inconsistencies in styling and behavior.
+
+### Problem
+
+The use of multiple alert component styles results in an inconsistent user experience and increases maintenance overhead by requiring support for multiple implementations.
+
+### Goals
+
+- Standardise the alert component across the application.
+- Minimise maintenance effort.
+- Ensure accessibility.
+- Align the alert component's styling with the Find Case Law service.
+
+## Options Considered
+
+1. Build a custom alert component.
+2. Use the GOV.UK Frontend alert component.
+3. Use the TNA Frontend alert component.
+4. Use the Home Office alert component.
+
+## Decision
+
+### Solution
+
+- Use the Home Office alert component.
+- Extract and integrate only this component rather than including the entire Home Office Frontend library.
+
+### Justification
+
+- The Home Office alert component aligns most closely with the Find Case Law styling, requiring minimal modifications.
+- Using a pre-existing, accessible component reduces development and maintenance effort compared to a custom implementation.
+- Extracting only the required component avoids unnecessary dependencies from the full Home Office Frontend library.
+
+## Consequences
+
+- The application will have a consistent and accessible alert component.
+- The extracted component will need to be manually maintained as an external dependency.

--- a/doc/adr/0026-playwright-for-end-to-end-tests.md
+++ b/doc/adr/0026-playwright-for-end-to-end-tests.md
@@ -1,0 +1,46 @@
+# 26. Playwright for End-to-End Testing
+
+**Date:** 2025-02-07
+**Status:** Accepted
+
+## Context
+
+### Background
+
+End-to-end (E2E) tests are required to ensure the Find Case Law website functions as expected while implementing changes and new features.
+
+### Problem
+
+Currently, end-to-end testing is performed manually, which is time-consuming, prone to being overlooked, and increases the risk of regressions in less frequently used areas of the website.
+
+### Goals
+
+- Implement automated end-to-end tests for critical user paths.
+- Integrate tests into the CI/CD pipeline for automated execution.
+- Use a well-maintained and widely adopted testing framework.
+- Ensure tests are written in a language all developers are comfortable with.
+
+## Options Considered
+
+1. **Cypress** – Popular and feature-rich but requires JavaScript/TypeScript.
+2. **Playwright** – Supports multiple languages, including Python, and is well-maintained.
+3. **Capybara** – Primarily used in Ruby environments, not suitable for this project.
+4. **Puppeteer** – JavaScript-based and less feature-complete for end-to-end testing compared to Playwright.
+
+## Decision
+
+### Solution
+
+Use **Playwright** for end-to-end testing.
+
+### Justification
+
+- Playwright supports Python, ensuring all developers can contribute to test writing and maintenance.
+- It is a well-maintained, widely adopted, and feature-rich testing framework.
+- Playwright provides robust support for modern web applications, including handling multiple browser contexts, network mocking, and parallel execution.
+
+## Consequences
+
+- End-to-end tests must be written and maintained for all critical user paths.
+- Automated testing will increase confidence in the stability of the service during development and deployment.
+- Updates to key user paths will require corresponding updates to the end-to-end tests.

--- a/doc/adr/0027-automated-accessibility-checking.md
+++ b/doc/adr/0027-automated-accessibility-checking.md
@@ -1,0 +1,45 @@
+# 27. Automated Accessibility Checking
+
+**Date:** 2025-02-07
+**Status:** Accepted
+
+## Context
+
+### Background
+
+Automating accessibility testing is necessary to ensure that the Find Case Law service meets accessibility standards consistently.
+
+### Problem
+
+Accessibility testing is currently a manual process with no standardised approach. As a result, accessibility best practices are often overlooked during development, leading to inconsistent compliance and potential usability issues.
+
+### Goals
+
+- Implement an automated process to flag accessibility issues in the codebase.
+- Standardise accessibility tests to ensure consistency and alignment with formal accessibility audits.
+
+## Options Considered
+
+1. **BrowserStack** – Provides accessibility testing as a service but adds external dependencies and potential cost overhead.
+2. **PA11Y** – An open-source tool, but requires additional configuration and does not integrate with Playwright.
+3. **Axe-Core** – A widely used accessibility engine, but would require additional scripting for automation.
+4. **Wave Chrome Extension with a test script** – Useful for manual checks but does not support automated testing.
+5. **Axe-Playwright** – A wrapper around Axe-Core that integrates directly with Playwright for automated accessibility testing.
+
+## Decision
+
+### Solution
+
+Integrate **Axe-Playwright** into the existing automated test suite to perform accessibility checks on all pages covered by end-to-end tests.
+
+### Justification
+
+- Seamlessly integrates with the existing Playwright-based testing setup.
+- Provides standardised accessibility checks aligned with industry best practices.
+- Works within the CI/CD pipeline, enabling continuous accessibility monitoring.
+
+## Consequences
+
+- All pages covered by end-to-end tests will undergo automated accessibility checks, ensuring key user journeys remain accessible.
+- Any new pages requiring accessibility validation must have corresponding Playwright tests.
+- Large feature implementations that introduce accessibility issues will need to be fixed before merging and releasing code.

--- a/doc/adr/0028-sass-for-all-css.md
+++ b/doc/adr/0028-sass-for-all-css.md
@@ -1,0 +1,47 @@
+# 28. Using SASS for All CSS
+
+**Date:** 2025-02-07
+**Status:** Accepted
+
+## Context
+
+### Background
+
+The Find Case Law front-end requires a maintainable and efficient styling approach.
+
+### Problem
+
+Writing styles in pure CSS is inefficient, difficult to maintain, and increases the risk of inconsistencies across the application.
+
+### Goals
+
+- Implement a simple and efficient approach to writing CSS.
+- Reduce duplication and promote reusability of styles.
+- Ensure compiled CSS is optimised for performance.
+
+## Options Considered
+
+1. **Pure CSS** – Lacks support for variables, mixins, and other features that improve maintainability.
+2. **LESS** – Similar to SCSS but less commonly used and supported in government services.
+3. **SCSS** – Widely used, flexible, and compatible with GOV.UK Frontend and other government-supported libraries.
+4. **Stylus** – Less commonly adopted and has a smaller ecosystem.
+5. **PostCSS** – Powerful but primarily used for processing CSS rather than writing styles directly.
+
+## Decision
+
+### Solution
+
+Adopt SCSS as the standard for all front-end styling in Find Case Law.
+
+### Justification
+
+- SCSS is widely used in public sector applications, including GOV.UK services.
+- Seamlessly integrates with government-supported libraries such as GOV.UK Frontend.
+- Enables writing efficient and maintainable CSS using variables, mixins, and nesting.
+- Supports compiling optimised CSS with reduced duplication.
+
+## Consequences
+
+- SCSS-supported libraries can be integrated more easily.
+- GOV.UK Frontend styles can be imported and customised as needed.
+- Styles will be more maintainable, efficient, and consistent across the application.

--- a/doc/adr/0029-css-spacing-variable-convention.md
+++ b/doc/adr/0029-css-spacing-variable-convention.md
@@ -1,0 +1,53 @@
+# 29. CSS Spacing Variable Convention
+
+**Date:** 2025-02-07
+**Status:** Accepted
+
+## Context
+
+### Background
+
+Spacing values across the application are currently inconsistent and do not follow a standardised convention.
+
+### Problem
+
+The lack of a consistent spacing convention results in:
+
+- Inconsistencies in user experience and visual design.
+- Increased maintenance overhead when adjusting spacing.
+- Difficulty in making layout changes efficiently.
+
+### Goals
+
+- Standardise spacing values across the Find Case Law front-end.
+- Reduce maintenance effort when updating spacing.
+- Provide a clear convention to enable faster development and modifications.
+
+## Options Considered
+
+1. **Use SCSS functions** – Generate spacing values dynamically based on a base size (e.g., `calc(base-size * 1.5)`).
+2. **Use named size variables** – Define a static set of variables (`xs`, `sm`, `lg`, `xl`) based on relative size.
+3. **Use numerical naming convention** – Define a static set of variables using a numbered scale (`space-1`, `space-2`, etc.).
+4. **Use variables that mimic values** – Define variables where the name directly reflects the value (e.g., `space-1` equals `1rem`).
+
+## Decision
+
+### Solution
+
+Adopt a static set of variables following a numerical naming convention (e.g., `space-1`, `space-2`, etc.).
+
+### Justification
+
+- SCSS functions add unnecessary cognitive complexity, as the output is not immediately clear when reading the SCSS.
+- Named size variables (e.g., `xs`, `sm`, `lg`) lack clear relationships between values, making it harder to determine spacing hierarchy.
+- Variables that mimic their values directly (e.g., `space-1 = 1rem`) create unnecessary maintenance overhead, as renaming would be required if values change.
+- A numerical naming convention provides:
+  - **Consistency** – Ensures predictable spacing across the application.
+  - **Maintainability** – Values can be adjusted without renaming variables.
+  - **Clarity** – Developers can easily compare spacing values in relation to each other.
+
+## Consequences
+
+- **Consistent user experience** – Spacing will be uniform across the website.
+- **Simplified development** – A clear convention reduces ambiguity and speeds up implementation.
+- **Easier maintenance** – Updating spacing values will not require renaming variables.

--- a/doc/adr/0030-css-typography-variable-convention.md
+++ b/doc/adr/0030-css-typography-variable-convention.md
@@ -1,0 +1,50 @@
+# 30. CSS Typography Variable Convention
+
+**Date:** 2025-02-07
+**Status:** Accepted
+
+## Context
+
+### Background
+
+Typography values across the application are currently inconsistent and lack a standardized convention.
+
+### Problem
+
+The absence of a consistent typography variable convention results in:
+
+- Inconsistent user experience and design.
+- Increased maintenance effort when updating typography.
+- Unclear guidance on which typography values to use in different contexts.
+
+### Goals
+
+- Standardize typography values across the Find Case Law front-end.
+- Reduce maintenance overhead when adjusting typography styles.
+- Establish a clear naming convention to streamline development.
+
+## Options Considered
+
+1. Define typography values inline with no convention – Leaves styling inconsistent and difficult to manage.
+2. Use SCSS functions to generate typography values dynamically – Increases cognitive complexity, making it harder to determine actual values.
+3. Use a named size convention – Define a static set of variables based on descriptive sizes (`xs`, `sm`, `lg`, `xl`).
+4. Use a numerical naming convention – Define a static set of variables using a numbered scale (`typography-1-text-size`, `typography-2-text-size`).
+5. Use variables that directly mimic values – Assign variable names to their exact values (e.g., `typography-1-text-size = 1rem`), making updates more difficult.
+
+## Decision
+
+### Solution
+
+Adopt a static set of variables following a named size convention (e.g., `typography-xs-text-size`, `typography-xl-text-size`).
+
+### Justification
+
+- Coupling typography variables to their intended use case ensures appropriate application and prevents misuse.
+- Named size conventions (e.g., `xs`, `sm`, `lg`, `xl`) are intuitive and immediately indicate their relative sizes.
+- Avoids ambiguity compared to numerical naming (`typography-1-text-size`), which does not convey whether the size is small or large (e.g., `h1` is large, but `1` is not inherently meaningful).
+
+## Consequences
+
+- **Consistent user experience** – Typography remains uniform across the website.
+- **Improved maintainability** – Updating typography styles will be straightforward and predictable.
+- **Easier development** – Developers can quickly understand and apply the correct typography variables.

--- a/doc/adr/0031-jest-for-javascript-unit-tests.md
+++ b/doc/adr/0031-jest-for-javascript-unit-tests.md
@@ -1,0 +1,47 @@
+# 31. Jest for JavaScript Unit Tests
+
+**Date:** 2025-02-07
+**Status:** Accepted
+
+## Context
+
+### Background
+
+The Find Case Law website includes various JavaScript functions that provide interactive features to users.
+
+### Problem
+
+- These JavaScript functions currently lack automated tests.
+- The code is complex enough that making changes without causing unintended issues is difficult.
+- There is no existing framework to ensure JavaScript functions behave as expected.
+
+### Goals
+
+- Implement automated unit tests for JavaScript functions.
+- Enable developers to modify JavaScript code confidently without introducing regressions.
+- Use a well-supported and widely adopted testing framework that is easy to learn and integrate.
+
+## Options Considered
+
+1. **Mocha** – A flexible testing framework but requires additional setup for assertions, mocks, and spies.
+2. **Jest** – A widely adopted testing framework with built-in support for assertions, mocking, and coverage reporting.
+3. **Jasmine** – A mature framework but less commonly used in modern JavaScript projects compared to Jest.
+
+## Decision
+
+### Solution
+
+Use **Jest** as the JavaScript unit testing framework.
+
+### Justification
+
+- Jest is the most widely adopted JavaScript testing framework, making it easy for developers to learn and use.
+- Provides built-in support for assertions, mocking, and code coverage, reducing setup complexity.
+- Actively maintained with strong community support.
+- Well-integrated with modern JavaScript tooling and frameworks.
+
+## Consequences
+
+- JavaScript functions will have automated unit tests, improving reliability and maintainability.
+- Developers can modify JavaScript code with greater confidence, reducing the risk of regressions.
+- Writing new JavaScript code will be more structured, as testability becomes a standard practice.

--- a/doc/adr/0032-standard-content-layout.md
+++ b/doc/adr/0032-standard-content-layout.md
@@ -1,0 +1,47 @@
+# 32. Standard Content Layout
+
+**Date:** 2025-02-07
+**Status:** Accepted
+
+## Context
+
+### Background
+
+The Find Case Law website includes multiple content pages, but their layouts are inconsistent and loosely defined.
+
+### Problem
+
+- Content pages do not follow a standardised format, leading to inconsistencies in structure and design.
+- Duplication of HTML across pages increases maintenance effort.
+- Adding new content pages without a clear structure introduces further inconsistencies.
+
+### Goals
+
+- Establish a standardised content layout for the majority of content pages.
+- Clearly define layout sections to ensure consistency and ease of extension.
+- Reduce HTML duplication across content pages.
+
+## Options Considered
+
+1. Maintain the current loosely defined format and migrate non-conforming content pages to it.
+2. Implement a new standardised content layout with clearly defined sections and move duplicated HTML to a base layout.
+
+## Decision
+
+### Solution
+
+- Implement a new standardised content layout with well-defined sections for different parts of the page.
+- Refactor existing content pages to follow this layout where appropriate.
+
+### Justification
+
+- Ensures a consistent content structure across the website.
+- Reduces duplication by centralising shared HTML elements in a base layout.
+- Makes it easier to add new content pages without introducing inconsistencies.
+
+## Consequences
+
+- Existing content pages must be updated to adopt the new layout.
+- New content pages will follow a predefined structure, simplifying development.
+- Future updates to the content layout will require fewer modifications across multiple pages.
+- Custom layouts will be needed for content pages that do not fit the standard format.

--- a/doc/adr/0033-govuk-front-end-css-overrides.md
+++ b/doc/adr/0033-govuk-front-end-css-overrides.md
@@ -1,0 +1,45 @@
+# 33. GOV.UK Front-End CSS Overrides
+
+**Date:** 2025-02-07
+**Status:** Accepted
+
+## Context
+
+### Background
+
+The Find Case Law website uses the GOV.UK Frontend CSS for styling components. However, some styles need to be overridden to better align with the service's design requirements.
+
+### Problem
+
+- There is a need to override certain GOV.UK Frontend styles while maintaining consistency.
+- Overrides should be structured in a maintainable and scalable way.
+
+### Goals
+
+- Provide a structured approach for overriding GOV.UK Frontend styles.
+- Ensure overrides are easy to manage and maintain.
+- Prevent duplication and inconsistencies in overridden styles.
+
+## Options Considered
+
+1. **Single global CSS file for all overrides** – Centralises overrides but becomes difficult to manage as the number of overrides grows.
+2. **Separate override files for each GOV.UK component** – Organises overrides per component, improving maintainability and discoverability.
+3. **Override styles inline where each GOV.UK component is used** – Leads to duplication and inconsistency across the application.
+
+## Decision
+
+### Solution
+
+Use separate CSS override files for each GOV.UK component that requires modifications.
+
+### Justification
+
+- Ensures consistency by centralising overrides per component.
+- Prevents duplication, as overrides are applied once and reused throughout the application.
+- Improves maintainability, making it easier to locate and modify specific component overrides.
+
+## Consequences
+
+- GOV.UK Frontend styles can be overridden in a structured and maintainable way.
+- Styling changes will be easier to track and modify when needed.
+- New overrides can be added systematically without affecting unrelated components.

--- a/doc/adr/0034-govuk-front-end-css-imports.md
+++ b/doc/adr/0034-govuk-front-end-css-imports.md
@@ -1,0 +1,42 @@
+# 34. GOV.UK Front-End CSS Imports
+
+**Date:** 2025-02-07
+**Status:** Accepted
+
+## Context
+
+### Background
+
+The Find Case Law website currently imports the entire GOV.UK Frontend CSS.
+
+### Problem
+
+- Importing the full GOV.UK CSS includes unnecessary styles for unused components.
+- This results in a larger CSS bundle, impacting performance.
+
+### Goals
+
+- Reduce the CSS bundle size by only including necessary styles.
+
+## Options Considered
+
+1. **Import the entire GOV.UK CSS** – Easier to maintain but includes unused styles, increasing bundle size.
+2. **Import only the CSS for the components in use** – Reduces bundle size while requiring explicit imports when new components are added.
+
+## Decision
+
+### Solution
+
+Only import the CSS for the GOV.UK components in use.
+
+### Justification
+
+- Reduces unnecessary CSS, improving performance.
+- New component styles can be added incrementally as needed.
+- Helps maintain a cleaner, more efficient stylesheet.
+
+## Consequences
+
+- Developers must manually import CSS when using a new GOV.UK component.
+- If a GOV.UK component is removed, its associated CSS import must also be removed.
+- The CSS bundle size will be reduced, improving load times and performance.

--- a/doc/adr/0035-bundled-javascript-vs-page-specific-javascript.md
+++ b/doc/adr/0035-bundled-javascript-vs-page-specific-javascript.md
@@ -1,0 +1,43 @@
+# 35. Bundled JavaScript vs. Page-Specific JavaScript
+
+**Date:** 2025-02-07
+**Status:** Accepted
+
+## Context
+
+### Background
+
+Currently, all JavaScript for the Find Case Law website is bundled into a single file and included on every page.
+
+### Problem
+
+- Pages load unnecessary JavaScript that is not required for their functionality.
+- This increases page load times and affects performance.
+
+### Goals
+
+- Improve page load times by reducing unnecessary JavaScript execution.
+
+## Options Considered
+
+1. **Continue serving all JavaScript on every page** – Simplifies implementation but negatively impacts performance.
+2. **Use an automated JavaScript compiler to split JavaScript** – Provides automatic code splitting but may require additional configuration and overhead.
+3. **Manually split JavaScript into modules and include only on relevant pages** – Ensures minimal JavaScript is loaded per page while maintaining control over what is included.
+
+## Decision
+
+### Solution
+
+Manually split JavaScript into module and include only on the relevant pages.
+
+### Justification
+
+- Reduces load times by ensuring only required JavaScript is loaded on each page.
+- JavaScript is only used on a few pages, making it feasible to manually manage module inclusion.
+- Provides better control over which scripts are loaded, avoiding unnecessary complexity from automated splitting tools.
+
+## Consequences
+
+- Pages will load faster due to reduced JavaScript execution.
+- Developers must ensure that JavaScript modules are explicitly included on the pages that require them.
+- Encourages a modular approach to writing JavaScript, improving maintainability.

--- a/doc/adr/0036-style-guide-page.md
+++ b/doc/adr/0036-style-guide-page.md
@@ -1,0 +1,42 @@
+# 36. Style Guide Page
+
+**Date:** 2025-02-07
+**Status:** Accepted
+
+## Context
+
+### Background
+
+The Find Case Law website contains numerous components used across different pages.
+
+### Problem
+
+- There is no centralised view of available components, their variations, or documentation explaining their intended use.
+- Developers and designers lack a clear reference for maintaining consistency across the website.
+
+### Goals
+
+- Provide a way to visualise all available components.
+- Document component variations and usage guidelines.
+
+## Options Considered
+
+1. **Use Storybook** – A widely used tool for component documentation, but primarily designed for React-based projects.
+2. **Build a custom style guide page** – A simple, standalone page listing components and their variations.
+
+## Decision
+
+### Solution
+
+Develop a style guide page to document and display available components.
+
+### Justification
+
+- Storybook is a powerful tool but is optimised for React-based applications, making it less suitable for Find Case Law.
+- A custom style guide page is simpler to implement and better suited to the existing technology stack.
+- Provides a centralised reference for developers and designers without requiring additional tooling.
+
+## Consequences
+
+- The style guide page will provide a single source of truth for component design and usage.
+- Developers will need to manually update the style guide as new components are added.

--- a/doc/adr/0037-webpack.md
+++ b/doc/adr/0037-webpack.md
@@ -1,0 +1,45 @@
+# 37. Webpack for JavaScript and CSS Compilation
+
+**Date:** 2025-02-07
+**Status:** Accepted
+
+## Context
+
+### Background
+
+The Find Case Law website includes JavaScript functions that provide interactive features to users. Additionally, modern JavaScript syntax and uncompiled CSS may not be compatible with older browsers and can lead to unnecessarily large payloads.
+
+### Problem
+
+- JavaScript syntax varies across versions, and some features may not be compatible with older browsers.
+- Without compilation and optimisation, JavaScript and CSS payload sizes can be unnecessarily large, affecting performance.
+
+### Goals
+
+- Ensure JavaScript is backward-compatible with older browsers.
+- Minimise JavaScript and CSS bundle sizes to improve performance.
+
+## Options Considered
+
+1. **Webpack** – A widely used, feature-rich bundler that supports JavaScript and CSS compilation.
+2. **ESBuild** – Extremely fast but less feature-complete and has limited plugin support for advanced bundling needs.
+3. **Rollup** – Optimised for JavaScript library bundling but less suitable for full applications with CSS processing.
+
+## Decision
+
+### Solution
+
+Use Webpack to compile JavaScript and CSS.
+
+### Justification
+
+- Webpack is an industry-standard tool with strong community support.
+- Provides comprehensive bundling capabilities, including JavaScript transpilation and CSS processing.
+- Supports backward compatibility for older browsers via Babel integration.
+- Offers tree shaking and code splitting, reducing unnecessary JavaScript payload.
+
+## Consequences
+
+- JavaScript and CSS will be compiled before deployment, introducing an additional build step.
+- Smaller bundle sizes will improve page load times.
+- JavaScript will be more compatible with a wider range of browsers.

--- a/doc/adr/0039-automatic-linting-before-code-push.md
+++ b/doc/adr/0039-automatic-linting-before-code-push.md
@@ -1,0 +1,44 @@
+# 39. Automatic Linting Before Code Push
+
+**Date:** 2025-02-07
+**Status:** Accepted
+
+## Context
+
+### Background
+
+The Find Case Law codebase uses multiple linting tools to enforce consistency and industry standards.
+
+### Problem
+
+- Developers must manually run linting tools, configure their editor to run them automatically, or wait for CI/CD validation after pushing code.
+- This can lead to inconsistencies, wasted CI/CD resources, and preventable errors being caught late in the development process.
+
+### Goals
+
+- Automatically enforce linting before code is pushed.
+- Reduce manual effort required for running linters.
+- Catch and fix linting issues early in the development workflow.
+
+## Options Considered
+
+1. **Use pre-commit hooks** – Runs linting checks before allowing a commit to be created.
+2. **Use pre-push hooks** – Runs linting checks before allowing a push to the remote repository.
+
+## Decision
+
+### Solution
+
+Use pre-commit hooks to enforce linting automatically before committing code.
+
+### Justification
+
+- Ensures that all committed code is linted and meets project standards.
+- Prevents developers from pushing non-compliant code and relying on CI/CD for linting validation.
+- Runs automatically on commit, requiring no manual intervention from developers.
+
+## Consequences
+
+- All committed code will be linted, ensuring consistency across the codebase.
+- Developers accustomed to frequent small commits may need to adjust to a slower workflow due to linting execution.
+- Developers must set up pre-commit hooks in each repository to ensure enforcement.

--- a/doc/adr/0040-atomic-css-classes.md
+++ b/doc/adr/0040-atomic-css-classes.md
@@ -1,0 +1,43 @@
+# 40. Atomic CSS Classes
+
+**Date:** 2025-02-07
+**Status:** Accepted
+
+## Context
+
+### Background
+
+The Find Case Law website includes a small number of atomic CSS classes.
+
+### Problem
+
+- Atomic CSS classes have not been fully adopted, leading to inconsistencies in styling.
+- Developers must reference multiple sources to understand how a component is styled, increasing cognitive complexity.
+
+### Goals
+
+- Establish a consistent approach to composing CSS.
+- Reduce the cognitive complexity of maintaining and modifying styles.
+
+## Options Considered
+
+1. Fully adopt atomic CSS classes across all components.
+2. Remove atomic CSS classes and rely on component-scoped styles.
+
+## Decision
+
+### Solution
+
+Remove atomic CSS classes in favor of component-scoped CSS.
+
+### Justification
+
+- Atomic CSS classes are not widely used and contribute to inconsistency rather than simplifying styling.
+- Removing them reduces complexity by consolidating styling within component-specific CSS.
+- A component-scoped approach improves readability and maintainability.
+
+## Consequences
+
+- Existing atomic CSS classes will need to be deprecated and replaced with component-scoped styles.
+- The transition will be incremental, requiring updates across the codebase.
+- The Find Case Law CSS will become easier to understand and maintain.

--- a/doc/adr/0041-cypress-for-end-to-end-tests.md
+++ b/doc/adr/0041-cypress-for-end-to-end-tests.md
@@ -1,0 +1,44 @@
+# 41. Cypress for End-to-End Tests
+
+**Date:** 2025-02-07
+**Status:** Accepted
+
+## Context
+
+### Background
+
+Cypress has been set up for end-to-end testing in the Find Case Law Editor User Interface project. However, it has never been fully configured and currently lacks tests. In contrast, Playwright has been properly configured in the Find Case Law Public User Interface repository and has extensive end-to-end tests.
+
+### Problem
+
+Using different tools for end-to-end testing across projects creates inconsistency and requires developers to switch between different testing frameworks. Maintaining both Cypress and Playwright would add unnecessary complexity.
+
+### Goals
+
+- Standardise end-to-end testing across projects.
+- Use a single tool to simplify development and maintenance.
+- Implement end-to-end tests in the Find Case Law Editor User Interface.
+
+## Options Considered
+
+1. Replace Cypress with Playwright.
+2. Replace Playwright with Cypress.
+3. Use a different end-to-end testing tool entirely.
+
+## Decision
+
+### Solution
+
+Replace Cypress with Playwright in the Find Case Law Editor User Interface.
+
+### Justification
+
+- Playwright is already fully configured and in use in the Find Case Law Public User Interface repository.
+- Standardising on Playwright allows developers to leverage existing knowledge and setup from the other repository.
+- Using a single testing framework reduces complexity and ensures consistency across projects.
+
+## Consequences
+
+- Cypress will be removed from the Find Case Law Editor User Interface as it is not currently used.
+- Playwright will be set up in the Find Case Law Editor User Interface, and end-to-end tests will be added.
+- The presence of end-to-end tests will provide greater confidence when making changes and implementing new features.

--- a/doc/adr/0042-jquery.md
+++ b/doc/adr/0042-jquery.md
@@ -1,0 +1,43 @@
+# 42. jQuery
+
+**Date:** 2025-02-07
+**Status:** Accepted
+
+## Context
+
+### Background
+
+jQuery is currently used for some functions in the Find Case Law Public User Interface, but not consistently across the project.
+
+### Problem
+
+Modern JavaScript, combined with a JavaScript compiler, now provides the backwards compatibility that jQuery once offered. Since this functionality is already available, jQuery is no longer necessary and adds unnecessary bloat to JavaScript bundles.
+
+### Goals
+
+- Reduce JavaScript bundle size.
+- Remove unnecessary dependencies.
+- Future-proof the codebase by using modern JavaScript.
+
+## Options Considered
+
+1. Keep jQuery.
+2. Remove jQuery and replace its functionality with modern JavaScript.
+
+## Decision
+
+### Solution
+
+Remove jQuery.
+
+### Justification
+
+- jQuery is no longer required for backward compatibility.
+- Removing jQuery will reduce the JavaScript bundle size.
+- Using modern JavaScript aligns with best practices and improves maintainability.
+
+## Consequences
+
+- Existing jQuery code will need to be rewritten in vanilla JavaScript.
+- JavaScript code will follow modern standards.
+- The JavaScript bundle will be smaller and more efficient.

--- a/doc/adr/0043-judgment-paragraph-anchors.md
+++ b/doc/adr/0043-judgment-paragraph-anchors.md
@@ -1,0 +1,43 @@
+# 43. Judgment Paragraph Anchors
+
+**Date:** 2025-02-07
+**Status:** Accepted
+
+## Context
+
+### Background
+
+Judgments include paragraph numbers, and users want the ability to link to specific paragraphs easily.
+
+### Problem
+
+There is currently no way for users to copy or share a direct link to a specific paragraph in a judgment.
+
+### Goals
+
+- Enable users to link directly to a specific paragraph in a judgment.
+- Provide an easy way for users to copy a link to a paragraph.
+
+## Options Considered
+
+1. Add links directly into the XML that generates the HTML.
+2. Dynamically add links to paragraphs using JavaScript.
+
+## Decision
+
+### Solution
+
+Use JavaScript to dynamically add links to paragraphs.
+
+### Justification
+
+- Features must degrade gracefully when JavaScript is disabled. Since clipboard functionality requires JavaScript, coupling the entire feature to JavaScript ensures a consistent implementation.
+- Modifying the XML generation process would require adding content that was not in the original document, which is undesirable.
+- JavaScript-based implementation keeps the feature isolated from the XML and base HTML, reducing complexity.
+
+## Consequences
+
+- The paragraph linking feature will only be available to users with JavaScript enabled.
+- The feature remains self-contained and does not impact the XML or base HTML.
+- It can be enabled or disabled via a feature flag.
+- Updates or modifications can be made without affecting multiple codebases.

--- a/doc/adr/0044-judgment-tables.md
+++ b/doc/adr/0044-judgment-tables.md
@@ -1,0 +1,43 @@
+# 44. Judgment Tables
+
+**Date:** 2025-02-07
+**Status:** Accepted
+
+## Context
+
+### Background
+
+Judgments often contain tables of varying structures and data formats.
+
+### Problem
+
+A single, standardised approach to rendering tables does not work across all judgments due to the diversity in content and formatting. In some cases, tables become illegible, making the current solution inadequate.
+
+### Goals
+
+- Ensure judgment tables are easy to read on desktop.
+- Ensure tables remain accessible and viewable on smaller devices.
+
+## Options Considered
+
+1. Require submitted judgments to follow a specific table format and reject non-compliant submissions.
+2. Modify the parser to convert all tables into a standard format.
+3. Implement CSS that works for the majority of judgment table cases.
+
+## Decision
+
+### Solution
+
+Implement CSS that supports the majority of judgment table cases.
+
+### Justification
+
+- Requiring authors to follow a strict table format is impractical.
+- Automatically converting tables via the parser is unreliable, as inferring context from a judgment is difficult.
+- A CSS-based solution allows tables to be displayed as intended while improving readability and accessibility across different devices.
+
+## Consequences
+
+- Judgment tables will remain as close as possible to their original format while being readable on both desktop and mobile.
+- Some tables may still require improvements, so CSS should be refined as needed while ensuring backward compatibility.
+- Authors of judgments will not need to change their current formatting practices.

--- a/doc/adr/0045-buttons.md
+++ b/doc/adr/0045-buttons.md
@@ -1,0 +1,45 @@
+# 45. Buttons
+
+**Date:** 2025-02-07
+**Status:** Accepted
+
+## Context
+
+### Background
+
+The application contains multiple types of buttons with varying styles and implementations.
+
+### Problem
+
+- There is little consistency in how buttons are styled and composed.
+- Different implementations have led to inconsistencies in the user experience and increased complexity when deciding how to style buttons.
+
+### Goals
+
+- Establish a core set of buttons with a standardised design.
+- Ensure consistent button styles across the Find Case Law Public User Interface.
+- Define a consistent approach to composing button styles.
+
+## Options Considered
+
+1. Define button mixins that can be imported into components.
+2. Define a set of button classes for use across the application.
+3. Style each button individually within its respective component.
+
+## Decision
+
+### Solution
+
+Define a set of button classes to be used consistently across the application.
+
+### Justification
+
+- Buttons are standalone components and should be treated as such.
+- Styling buttons via mixins within other components could introduce inconsistencies as additional styles are applied on a per-component basis.
+- Using predefined button classes ensures consistency and avoids unnecessary duplication of styles.
+
+## Consequences
+
+- Using button mixins will be **deprecated** in favor of using button classes for new components.
+- Buttons will have consistent styling throughout the Find Case Law Public User Interface.
+- Composing components that use buttons will be simpler and more predictable.

--- a/doc/adr/0046-link-classes-for-analytics.md
+++ b/doc/adr/0046-link-classes-for-analytics.md
@@ -1,0 +1,41 @@
+# 46. Link Classes for Analytics
+
+**Date:** 2025-02-12
+**Status:** Proposed
+
+## Context
+
+### Background
+
+The Find Case Law Public User Interface contains many links that need to be tracked for analytics purposes.
+
+### Problem
+
+Google Analytics no longer automatically tracks button text for events. Instead, it relies on element classes to determine which link triggered an event.
+
+### Goals
+
+- Enable Google Analytics users to easily identify which link triggered an event.
+- Implement a low-maintenance solution that requires minimal developer intervention.
+
+## Options Considered
+
+1. Manually add a link class to all tracked links.
+2. Use a django template tag to automatically append an analytics class to links.
+
+## Decision
+
+### Solution
+
+Implement a django template tag that automatically adds an analytics-specific class to links.
+
+### Justification
+
+- Keeping analytics-related classes separate ensures they do not interfere with functional classes used for styling or other purposes.
+- Automating class assignment through a template tag reduces manual effort and minimises the chance of inconsistent analytic classes.
+
+## Consequences
+
+- Google Analytics users will be able to easily track which links trigger events.
+- Analytics classes will be isolated to avoid conflicts with existing styles.
+- The template tag will need to be implemented and applied to all relevant links.


### PR DESCRIPTION
Adds 1 proposed ADR:

 - [x] 46. Link Classes for Analytics

And adds the following ADRs that are already accepted:

 - [x] 22. TNA Front-End Colour Overrides
 - [x] 23. StyleLint Configuration
 - [x] 24. Usage of GOV.UK Front-End
 - [x] 25. Usage of Home Office Front-End
 - [x] 26. Playwright for End-to-End Testing
 - [x] 27. Automated Accessibility Checking
 - [x] 28. Using SASS for All CSS
 - [x] 29. CSS Spacing Variable Convention
 - [x] 30. CSS Typography Variable Convention
 - [x] 31. Jest for JavaScript Unit Tests
 - [x] 32. Standard Content Layout
 - [x] 33. GOV.UK Front-End CSS Overrides
 - [x] 34. GOV.UK Front-End CSS Imports
 - [x] 35. Bundled JavaScript vs. Page-Specific JavaScript
 - [x] 36. Style Guide Page
 - [x] 37. Webpack for JavaScript and CSS Compilation
 - [x] 39. Automatic Linting Before Code Push
 - [x] 40. Atomic CSS Classes
 - [x] 41. Cypress for End-to-End Tests
 - [x] 42. jQuery
 - [x] 43. Judgment Paragraph Anchors
 - [x] 44. Judgment Tables
 - [x] 45. Buttons