### PR TITLE
Swap Renovate configuration to use best practices

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
+    "config:best-practices",
     ":approveMajorUpdates",
     ":automergeLinters",
     ":automergePatch",

--- a/default.json
+++ b/default.json
@@ -9,7 +9,6 @@
     ":automergeRequireAllStatusChecks",
     ":automergeTesters",
     ":maintainLockFilesWeekly",
-    ":dependencyDashboard",
     ":enablePreCommit"
   ],
   "timezone": "Europe/London",


### PR DESCRIPTION
This switches from using just the recommended practices to using the best practices, which includes things like pinning GitHub Actions and Docker containers to digests rather than tags (so they can't be transparently swapped out).