### PR TITLE
Allow Renovate to attempt immediate updates for our first-party packages

### DIFF
--- a/default.json
+++ b/default.json
@@ -23,6 +23,14 @@
     {
       "matchPackagePatterns": ["boto"],
       "groupName": "boto packages"
+    },
+    {
+      "matchPackageNames": [
+        "ds-caselaw-utils",
+        "ds-caselaw-custom-api-client",
+        "ds-caselaw-frontend"
+      ],
+      "minimumReleaseAge": "0 days"
     }
   ],
   "labels": ["dependencies"],


### PR DESCRIPTION
At the moment our `ds-caselaw-utils`, `ds-caselaw-custom-api-client` and `ds-caselaw-frontend` packages are configured to wait two days (as per the default `minimumReleaseAge`) before Renovate will attempt to update them.

Change this behaviour so it will attempt the updates immediately, since we trust our own packages.