### PR TITLE
Another draft of ADR21

### DIFF
--- a/doc/adr/0021-xml-with-no-docx.md
+++ b/doc/adr/0021-xml-with-no-docx.md
@@ -67,7 +67,7 @@ The following elements have been in use for some time:
 
 - **uk:parser** - The version of the parser used to generate the XML. Example: `<uk:parser>0.22.1</uk:parser>`. Should always be present.
 
-- **uk:hash** - The hash of the document's contents. Example: `<uk:hash>addee6a43d69dee4e62c9ccbf27df98874b4967a385397bed610cc414ee45c84</uk:hash>`. The SHA-256 hash of the document text, with all whitespace removed.
+- **uk:hash** - The hash of the document's contents. Example: `<uk:hash>addee6a43d69dee4e62c9ccbf27df98874b4967a385397bed610cc414ee45c84</uk:hash>`. The SHA-256 hash of the document text with all whitespace removed.
 
 - **uk:tna-enrichment-engine** - The version of the enrichment engine used to identify references within the body of the XML.
 

--- a/doc/adr/0021-xml-with-no-docx.md
+++ b/doc/adr/0021-xml-with-no-docx.md
@@ -53,7 +53,7 @@ The following elements have been in use for some time:
 
 - **uk:court** - A code designating the court that issued the judgment or decision. Example: `<uk:court>UKSC</uk:court>`. Can be missing if the court is unknown. If present, its value will be one of a list of enumerated values. This code was created by us; it does not appear in the text.
 
-- **uk:year** - The year of the judgment's number. Example: `<uk:year>2025</uk:year>`. Can be missing if unknown. If present, its value will be a four-digit integer. Note this is not always the same year as the judgment's handed-down date. Rarely, in the early days of January, a judgment will be numbered based on the prior year. A component of the judgment's Neutral Citation Number; extracted here for efficient search indexing.
+- **uk:year** - The year as defined in the judgment's NCN, where extracted. Example: `<uk:year>2025</uk:year>` where the NCN is `[2025] UKSC 1`. Can be missing if NCN not extracted. If present, its value will be a four-digit integer. Note this is not always the same year as the judgment's handed-down date. Rarely, in the early days of January, a judgment will be numbered based on the prior year. Extracted for efficient search indexing.
 
 - **uk:number** - The number of the judgment, assigned by the court. Unique within a court and year. Used for sorting. Example: `<uk:number>1</uk:number>`. Can be missing if unknown. If present, its value will be an integer. A component of the judgment's Neutral Citation Number; extracted here for efficient search indexing.
 

--- a/doc/adr/0021-xml-with-no-docx.md
+++ b/doc/adr/0021-xml-with-no-docx.md
@@ -1,6 +1,6 @@
-# 21. XML format for documents where source text cannot be extracted by the parser
+# 21. Additional metadata fields for backlog judgments
 
-Date: 2024-11-20
+Date: 2025-05-12
 
 ## Status
 
@@ -8,123 +8,99 @@ Draft
 
 ## Context
 
-We need to support documents where the structured contents of the document cannot necessarily be extracted by the parser. They will typically be PDF-only, although we're imagining there might be other formats (such as zip files full of jpegs).
+Up to now, our parser has converted new court judgments from Word format (.docx) into Akoma Ntoso, an XML schema for legal documents. It attempts to identify key information in the body of the judgment and tags it with semantic inline elements. Sometimes, when the schema requires or when the body elements do not suit our needs, the parser also duplicates this information in the metadata header. But other times, when the body elements are sufficient, it does not. For example, we can search documents based on values in inline elements, so search optimization alone is not a reason to copy data to the metadata header.
 
-These documents might not have neutral ciation numbers -- this is outside the scope of this document.
+Furthermore, sometimes we need information in the metadata block, but the schema does not provide any native markup for the values we have. The Akoma Ntoso schema has a `<proprietary>` element in its metadata block, into which we can put custom elements.
+
+Recently, we have been asked to publish old documents, some of which are available in Word format, but others are available only in PDF. For the Word documents, we parse them as usual. For the PDFs, we do not attempt to extract any text; rather, we create an XML stub containing only metadata.
+
+For these older documents, we also receive separate metadata files containing information about each document. We want to incorporate that metadata into the XML. For PDF documents, this external metadata is the only metadata we will have. But for old Word documents, we will have two sources of metadata: the _internal_ metadata our parser identifies through its normal process and the _external_ metadata we have been given.
 
 ## Decision
 
-The parser will emit an XML document similar to what is currently provided, but with some differences to support the lack of high-quality formatting data
+We will expand our use of the Akoma Ntoso `<proprietary>` element to store additional metadata for backlog judgments.
 
-### Structurally valid (modified) AkomaNtoso
+### Proprietary Metadata Elements
 
-The emitted XML will validate against our modified AkomaNtoso schema
+We will use the following elements within the `<proprietary>` block:
 
-### Search Compatible External Metadata
-
-Metadata is provided to the parser via spreadsheets. We will want to preserve some of this data.
-
-The existing tag names (see the appendix) will be used inside a `uk:external-metadata` tag in the `proprietary` tag to allow this metadata to be searched at the same time as other documents that have these tags in the running body of the judgment; however, `akn:` namespaced tags are forbidden, so the `uk:` namespace MUST be used instead.
-
-Values MUST NOT be deliberately replicated across `external-metadata` and other places, but MAY be replicated if the text body is successfully parsed and the string appeared in externally provided data sources.
-
-Editors SHOULD be able to edit these metadata values within the `proprietary` tag and the Editor UI have affordances to do so.
-
-### Marked as Low Quality
-
-The `proprietary` tag will contain a `uk:source-document` tag, containing two fractional attributes:
-
-Each of these numerical metrics defaults to `1.0`: we have no reason to doubt the quality of the document. Values of `0.0` imply a complete lack of quality, or an absence of that feature. Values below `0.5` should be considered poor, and mitigations applied. Values above `1.0` might be signs of additional verification.
-
-- `uk:markup-quality-score`: Is the body of the document marked up well with appropriate HTML and AkomaNtoso tags?
-
-- `uk:text-quality-score`: Are all the words believed to be in the right order, with appropriate interword spacing? (Linebreaks optional)
-
-There is also:
-
-- `uk:source-document-format`: the MIME type of the document from which this XML was generated. For Rich Text
-  documents, and others where the document was converted to docx first, the mime type still will be `application/vnd.openxmlformats-officedocument.wordprocessingml.document`;
-
-- `uk:markup-human-reviewed`: boolean -- An editor has reviewed the document. This will not be added by any parser, but may be added in the EUI.
-
-- `uk:quality-warning`: Human readable text warning that the XML is low quality and should not be relied upon.
-
-### Purposes for Low Quality Marks
-
-#### Rejected for Impossible Tasks
-
-Documents with no DOCX cannot be reparsed via the existing framework, so SHOULD be excluded from the list of reparse candidates, SHOULD NOT be reparsable in the UI and MUST not be sent for reparsing.
-
-Documents without text SHOULD NOT be sent to enrichment.
-
-#### Hidden Information
-
-The Atom Feed MAY allow searching for only documents with sufficient quality scores.
-
-The Public UI SHOULD NOT attempt to display XML or HTML transforms of XML to users where the text and/or markup quality scores are insufficient. (0.5 is probably the threshold)
-
-XML representations MAY be available to users who explicitly request them but SHOULD NOT be routinely displayed
-in the PUI.
-
-#### Warning the user
-
-The Public UI SHOULD indicate to users that a document is not available as HTML and instead is only available
-as the original source document (or other compiled artifact in the future)
-
-### Mediocre-Effort Text
-
-An attempt SHOULD be made to extract full text from the document to support full text search. The parser MAY mark it up beyond the minimum to achieve AkomaNtoso compliance, but this is not expected. The parser MAY identify output which contains a high-proportion of non-words, and SHOULD emit no text if the text quality is sufficiently poor, and will have to do so if there is no text available.
-
-## Consequences
-
-- Full text search preserved
-- Bad data not shown to users
-- Search experience preserved
-
----
-
-## Appendix: Current Search XPATH
-
-### Party
-
-element word query on `akn:party` OR
-
-element attribute word `akn:FRBRname/@value`
-
-### Court
-
-element value query on `judgments:court` (!) OR
-
-element value query on `uk:court` OR
-
-element attribute word query on `akn:FRBRuri/@value`
-
-### Judge
-
-element word query on `akn:judge`
-
-### Dates from/to
-
-path range query on `akn:FRBRWork/akn:FRBRdate/@date`
-
-### Neutral Citation
-
-element value query on akn:cite
-
-### Keyword
-
-word query, unstemmed, anywhere?
-
-### Display
-
-```akn:proprietary/uk:court
-akn:proprietary/uk:year
-akn:FRBRWork/akn:FRBRdate
-akn:FRBRWork/akn:FRBRname
-uk:cite
-akn:neutralCitation
-uk:court
-uk:jurisdiction
-uk:hash
-akn:FRBRManifestation/akn:FRBRdate
+```xml
+<proprietary xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
+    <uk:court/>                 <!-- 0 or 1 -->
+    <uk:year/>                  <!-- 0 or 1 -->
+    <uk:number/>                <!-- 0 or 1 -->
+    <uk:cite/>                  <!-- 0 or 1 -->
+    <uk:summaryOf/>             <!-- 0 or 1 -->
+    <uk:summaryOfCite/>         <!-- 0 or 1 -->
+    <uk:caseNumber/>            <!-- 0 or many -->
+    <uk:jurisdiction/>          <!-- 0 or 1 -->
+    <uk:party role=""/>         <!-- 0 or many -->
+    <uk:category parent=""/>    <!-- 0 or many -->
+    <uk:sourceFormat/>          <!-- 0 or 1 -->
+    <uk:parser/>                <!-- 1 -->
+    <uk:hash/>                  <!-- 1 -->
+    <uk:tna-enrichment-engine/> <!-- 0 or 1 -->
+</proprietary>
 ```
+
+Elements MUST appear in the order listed above. Some elements may be omitted if not applicable, but the relative order of included elements must be maintained.
+
+### Element Definitions
+
+**Original Elements:**
+
+The following elements have been in use for some time:
+
+- **uk:court** - A code designating the court that issued the judgment or decision. Example: `<uk:court>UKSC</uk:court>`. Can be missing if the court is unknown. If present, its value will be one of a list of enumerated values. This code was created by us; it does not appear in the text.
+
+- **uk:year** - The year of the judgment's number. Example: `<uk:year>2025</uk:year>`. Can be missing if unknown. If present, its value will be a four-digit integer. Note this is not always the same year as the judgment's handed-down date. Rarely, in the early days of January, a judgment will be numbered based on the prior year. A component of the judgment's Neutral Citation Number; extracted here for efficient search indexing.
+
+- **uk:number** - The number of the judgment, assigned by the court. Unique within a court and year. Used for sorting. Example: `<uk:number>1</uk:number>`. Can be missing if unknown. If present, its value will be an integer. A component of the judgment's Neutral Citation Number; extracted here for efficient search indexing.
+
+- **uk:cite** - The Neutral Citation Number of the judgment or decision, assigned by the court. Example: `<uk:cite>[2025] UKSC 1</uk:cite>`. Can be missing if unknown. Although this is also marked up in the body of the text, we duplicate it here because occasionally there are punctuation errors in the body, and we want a normalized form here.
+
+- **uk:summaryOf** - The URI of the judgment summarized by this press summary. Example: `<uk:summaryOf>https://caselaw.nationalarchives.gov.uk/id/uksc/2025/18</uk:summaryOf>`. Only present in press summaries. Can be missing if not known.
+
+- **uk:summaryOfCite** - The Neutral Citation Number of the judgment summarized by this press summary. Example: `<uk:summaryOfCite>[2025] UKSC 18</uk:summaryOfCite>`. Only present in press summaries. Can be missing if not known.
+
+- **uk:jurisdiction** - A code indicating the subject matter of the case over which the court has jurisdiction. Example: `<uk:jurisdiction>InformationRights</uk:jurisdiction>`. Currently used only for the General Regulatory Chamber. Can be missing if not known. Currently there will never be more than one of these elements, although it is conceivable we may want to allow multiple values in the future.
+
+- **uk:parser** - The version of the parser used to generate the XML. Example: `<uk:parser>0.22.1</uk:parser>`. Should always be present.
+
+- **uk:hash** - The hash of the document's contents. Example: `<uk:hash>addee6a43d69dee4e62c9ccbf27df98874b4967a385397bed610cc414ee45c84</uk:hash>`. The SHA-256 hash of the document text, with all whitespace removed.
+
+- **uk:tna-enrichment-engine** - The version of the enrichment engine used to identify references within the body of the XML.
+
+**New Elements:**
+
+We will introduce the following additional elements for backlog documents:
+
+- **uk:caseNumber** - A case number assigned by the court. Example: `<uk:caseNumber>2001/2/RTR</uk:caseNumber>`. Can be missing. There can also be more than one, as some judgments relate to more than one case.
+
+- **uk:party** - A name of one of the parties in the case, and optionally the role played. Example: `<uk:party role="Claimant">Rosecal &amp; Co Law Firm</uk:party>`. May be none if unknown. May be more than one.
+
+- **uk:category** - The name of a category, assigned by the court, and optionally the name of a parent category, if the category is a subcategory. Example: `<uk:category parent="Some Parent">Refusal to register</uk:category>`. May be none if unknown. The `parent` attribute is optional.
+
+- **uk:sourceFormat** - The MIME type of the source document. Example: `<uk:sourceFormat>application/vnd.openxmlformats-officedocument.wordprocessingml.document</uk:sourceFormat>`. Currently added only for backlog judgments.
+
+### Element Usage Notes for each Type of Document
+
+1. **New documents in Word format (no external metadata)**
+   - Contain the original proprietary fields, if the parser can identify them
+   - Do not contain `<uk:caseNumber/>`, `<uk:party/>`, `<uk:category>` or `<uk:sourceFormat/>`
+   - Party names and case numbers are marked up in the body text only
+
+2. **Old documents in PDF format (with external metadata)**
+   - May contain some or all of the proprietary fields, if the information was provided in external metadata
+   - No body text markup will be present
+
+3. **Old documents in Word format (with external metadata)**
+   - May contain some or all of the proprietary fields
+   - May include both proprietary metadata elements AND body text markup for the same information
+   - For example, if the parser identifies a party name in the body, it will mark it in place, but if the party name was also provided in the external metadata, the external value will appear in the proprietary section
+
+## Considerations
+
+- We could add a `<uk:sourceFormat/>` element to new judgments, or we could move this information to the JSON metadata for backlog judgments.
+- We could add a `source` attribute to some proprietary elements, to indicate the provenance of the value.
+- We could use the `<uk:caseNumber/>` and `<uk:party/>` elements also for new judgments, duplicating information for consistency with backlog document.

--- a/doc/adr/0021-xml-with-no-docx.md
+++ b/doc/adr/0021-xml-with-no-docx.md
@@ -51,7 +51,7 @@ Elements MUST appear in the order listed above. Some elements may be omitted if 
 
 The following elements have been in use for some time:
 
-- **uk:court** - A code designating the court that issued the judgment or decision. Example: `<uk:court>UKSC</uk:court>`. Can be missing if the court is unknown. If present, its value will be one of a list of enumerated values. This code was created by us; it does not appear in the text.
+- **uk:court** - A code designating the court that issued the judgment or decision. Example: `<uk:court>UKFTT-GRC</uk:court>`. Can be missing if the court is unknown. If present, its value will be one of a list of enumerated values. This code was created by us; it does not appear in the text.
 
 - **uk:year** - The year as defined in the judgment's NCN, where extracted. Example: `<uk:year>2025</uk:year>` where the NCN is `[2025] UKSC 1`. Can be missing if NCN not extracted. If present, its value will be a four-digit integer. Note this is not always the same year as the judgment's handed-down date. Rarely, in the early days of January, a judgment will be numbered based on the prior year. Extracted for efficient search indexing.
 

--- a/doc/adr/0021-xml-with-no-docx.md
+++ b/doc/adr/0021-xml-with-no-docx.md
@@ -55,9 +55,9 @@ The following elements have been in use for some time:
 
 - **uk:year** - The year as defined in the judgment's NCN, where extracted. Example: `<uk:year>2025</uk:year>` where the NCN is `[2025] UKSC 1`. Can be missing if NCN not extracted. If present, its value will be a four-digit integer. Note this is not always the same year as the judgment's handed-down date. Rarely, in the early days of January, a judgment will be numbered based on the prior year. Extracted for efficient search indexing.
 
-- **uk:number** - The number of the judgment, assigned by the court. Unique within a court and year. Used for sorting. Example: `<uk:number>1</uk:number>`. Can be missing if unknown. If present, its value will be an integer. A component of the judgment's Neutral Citation Number; extracted here for efficient search indexing.
+- **uk:number** - The number of the judgment, assigned by the court. Unique within a court and year. Used for sorting. Example: `<uk:number>1</uk:number>`. Can be missing if there's no NCN. If present, its value will be an integer. A component of the judgment's Neutral Citation Number; extracted here for efficient search indexing.
 
-- **uk:cite** - The Neutral Citation Number of the judgment or decision, assigned by the court. Example: `<uk:cite>[2025] UKSC 1</uk:cite>`. Can be missing if unknown. Although this is also marked up in the body of the text, we duplicate it here because occasionally there are punctuation errors in the body, and we want a normalized form here.
+- **uk:cite** - The Neutral Citation Number of the judgment or decision, assigned by the court. Example: `<uk:cite>[2025] UKSC 1</uk:cite>`. Can be missing if there's no NCN. Although this is also marked up in the body of the text, we duplicate it here because occasionally there are punctuation errors in the body, and we want a normalized form here.
 
 - **uk:summaryOf** - The URI of the judgment summarized by this press summary. Example: `<uk:summaryOf>https://caselaw.nationalarchives.gov.uk/id/uksc/2025/18</uk:summaryOf>`. Only present in press summaries. Can be missing if not known.
 
@@ -77,20 +77,22 @@ We will introduce the following additional elements for backlog documents:
 
 - **uk:caseNumber** - A case number assigned by the court. Example: `<uk:caseNumber>2001/2/RTR</uk:caseNumber>`. Can be missing. There can also be more than one, as some judgments relate to more than one case.
 
-- **uk:party** - A name of one of the parties in the case, and optionally the role played. Example: `<uk:party role="Claimant">Rosecal &amp; Co Law Firm</uk:party>`. May be none if unknown. May be more than one.
+- **uk:party** - A name of one of the parties in the case, and optionally the role played. Example: `<uk:party role="Claimant">Rosecal &amp; Co Law Firm</uk:party>`. May not exist if not extracted. May be more than one.
 
-- **uk:category** - The name of a category, assigned by the court, and optionally the name of a parent category, if the category is a subcategory. Example: `<uk:category parent="Some Parent">Refusal to register</uk:category>`. May be none if unknown. The `parent` attribute is optional.
+- **uk:category** - The name of a category, assigned by the court, and optionally the name of a parent category, if the category is a subcategory. Example: `<uk:category parent="Some Parent">Refusal to register</uk:category>`. May be none, many courts don't have categories. The `parent` attribute is optional.
 
 - **uk:sourceFormat** - The MIME type of the source document. Example: `<uk:sourceFormat>application/vnd.openxmlformats-officedocument.wordprocessingml.document</uk:sourceFormat>`. Currently added only for backlog judgments.
 
 ### Element Usage Notes for each Type of Document
 
 1. **New documents in Word format (no external metadata)**
+
    - Contain the original proprietary fields, if the parser can identify them
    - Do not contain `<uk:caseNumber/>`, `<uk:party/>`, `<uk:category>` or `<uk:sourceFormat/>`
    - Party names and case numbers are marked up in the body text only
 
 2. **Old documents in PDF format (with external metadata)**
+
    - May contain some or all of the proprietary fields, if the information was provided in external metadata
    - No body text markup will be present
 

--- a/doc/adr/0021-xml-with-no-docx.md
+++ b/doc/adr/0021-xml-with-no-docx.md
@@ -89,7 +89,7 @@ We will introduce the following additional elements for backlog documents:
 
    - Contain the original proprietary fields, if the parser can identify them
    - Do not contain `<uk:caseNumber/>`, `<uk:party/>`, `<uk:category>` or `<uk:sourceFormat/>`
-   - Party names and case numbers are marked up in the body text only
+   - Party names (`<party>`) and case numbers (`<docketNumber>`) are marked up in the body text only
 
 2. **Old documents in PDF format (with external metadata)**
 


### PR DESCRIPTION
Here's another draft of ADR21. I've taken it a slightly different direction, focusing on the use of proprietary metadata for new documents, backlog documents available in PDF, and backlog documents available in Word.