### PR TITLE
[FCL-874] Swap automerge behaviour to merge minor updates, not just patch

### DIFF
--- a/default.json
+++ b/default.json
@@ -4,7 +4,7 @@
     "config:best-practices",
     ":approveMajorUpdates",
     ":automergeLinters",
-    ":automergePatch",
+    ":automergeMinor",
     ":automergePr",
     ":automergeRequireAllStatusChecks",
     ":automergeTesters",


### PR DESCRIPTION
We usually merge minor updates which pass all the tests without further investigation as a matter of routine, so we may as well make the computer do it.