### PR TITLE
Add email the devs to API docs and rephrase user research signup

### DIFF
--- a/doc/adr/0010-interface-with-enrichment.md
+++ b/doc/adr/0010-interface-with-enrichment.md
@@ -16,7 +16,6 @@ and presented our decisions to a meeting on the 27th September.
 
 - Find Case Law (dxw) will place a notification onto an SNS topic that it manages when an document is edited. If there is a need to be able to retry the lambda, it is possible for Enrichment to subscribe an SQS queue to the topic so they have visibility and control.
 - That notification will contain a JSON dictionary, with at least the following keys:
-
   - `uri_reference`: the document that is being notified about, e.g. `ewhc/fam/2022/2134`, which can be appended to API endpoints like `api.caselaw.nationalarchives.gov.uk/lock/ewhc/fam/2022/2134`
   - `status`: currently the status of the document when edited: `published` implies the document has previously or just now been published; `not published` implies the document has never been published or has been unpublished.
     In total this may look like: `{"uri_reference": "ewhc/fam/2022/2134", "status": "published"}`

--- a/doc/adr/0021-xml-with-no-docx.md
+++ b/doc/adr/0021-xml-with-no-docx.md
@@ -86,13 +86,11 @@ We will introduce the following additional elements for backlog documents:
 ### Element Usage Notes for each Type of Document
 
 1. **New documents in Word format (no external metadata)**
-
    - Contain the original proprietary fields, if the parser can identify them
    - Do not contain `<uk:caseNumber/>`, `<uk:party/>`, `<uk:category>` or `<uk:sourceFormat/>`
    - Party names (`<party>`) and case numbers (`<docketNumber>`) are marked up in the body text only
 
 2. **Old documents in PDF format (with external metadata)**
-
    - May contain some or all of the proprietary fields, if the information was provided in external metadata
    - No body text markup will be present
 

--- a/doc/openapi/public_api.yml
+++ b/doc/openapi/public_api.yml
@@ -75,9 +75,11 @@ info:
 
     ## Give us your feedback
 
-    We are still actively developing Find Case Law based on user feedback. This includes improving the experience of how data re-users can access the data.
+    We are still actively developing Find Case Law based on user feedback.
+    This includes improving the experience of how data re-users can access the data.
+    You can provide feedback by emailing [caselaw@nationalarchives.gov.uk](mailto:caselaw@nationalarchives.gov.uk?subject=Attn%20Developers:) marked for the attention of the developers.
 
-    You can provide feedback by using our [feedback form](https://www.smartsurvey.co.uk/s/CaseLaw-research/).
+    If you'd be interested in participating in our user research, please [sign up](https://www.smartsurvey.co.uk/s/CaseLaw-research/).
   termsOfService: "https://caselaw.nationalarchives.gov.uk/terms-of-use"
   contact:
     email: caselaw@nationalarchives.gov.uk


### PR DESCRIPTION
Out of the ICLR discussions, we decided a quick way of contacting the devs should be via the inbox. Publicise this somewhat, and make the signup link for user research less painful.
https://dxw.slack.com/archives/C092DNYL6TH/p1750776579275429