### PR TITLE
Automerge digest updates from tdr-github-actions

### DIFF
--- a/default.json
+++ b/default.json
@@ -31,6 +31,10 @@
         "ds-caselaw-frontend"
       ],
       "minimumReleaseAge": "0 days"
+    },
+    {
+      "matchPackageNames": ["nationalarchives/tdr-github-actions"],
+      "automerge": true
     }
   ],
   "labels": ["dependencies"],


### PR DESCRIPTION
Modify our Renovate configuration so that digest updates to `nationalarchives/tdr-github-actions` are merged automatically (assuming tests pass).

Since these are unversioned updates they don't currently meet any of our automerge rules, and just create noise (because we trust them and merge them pretty much regardless unless tests fail).