### PR TITLE
[FCL-1183] Document the API's rate limits

### DIFF
--- a/doc/openapi/public_api.yml
+++ b/doc/openapi/public_api.yml
@@ -15,7 +15,7 @@ info:
 
     **The Open Justice licence does not permit computational analysis.** If you intend to do any programmatic searching in bulk across the Find Case Law records to identify, extract or enrich contents within the records you will need to [apply to perform computational analysis](https://caselaw.nationalarchives.gov.uk/re-use-find-case-law-records/licence-application-process). There are no application charges.
 
-    ## Identifying documents
+    ## Document identifiers
 
     Documents in Find Case Law are identified in two different ways, one which is better for machines and one which is better for humans:
 
@@ -31,9 +31,9 @@ info:
 
     Documents submitted to the National Archives from April 2025 onwards will usually have a URI which looks something like `d-f11e093f-8a53-4e43-8dd8-1531b5d8f018`. These will always begin with a `d-`.
 
-    ### Document identifiers
+    ### Structured identifiers
 
-    In addition to the Document URI, all documents will also have one or more "identifiers" which exist under different schemes. This currently includes Find Case Law Identifiers (for all documents) and Neutral Citation Numbers (for judgments which have them), but may be extended in future.
+    In addition to the Document URI, all documents will also have one or more "structured identifiers" representing ways which humans can refer to a document. This currently includes Find Case Law Identifiers (for all documents) and Neutral Citation Numbers (for judgments which have them), but may be extended in future.
 
     Each identifier will have – as a minimum – a `type`, a `value` and a `slug` which can be turned into a human-facing URL by appending it to `https://caselaw.nationalarchives.gov.uk`.
 

--- a/doc/openapi/public_api.yml
+++ b/doc/openapi/public_api.yml
@@ -1,7 +1,7 @@
 openapi: 3.1.1
 info:
   title: "National Archives Find Case Law: Public API"
-  version: 0.5.0
+  version: 0.5.1
   description: |-
     Our API provides access to judgments and other documents held by The National Archives and published via the Find Case Law service.
 
@@ -50,6 +50,12 @@ info:
 
     Each document will have exactly one preferred identifier, determined by the Find Case Law system, which it will prefer for displaying to users and generating public-facing URLs. You must _not_ make any assumptions about the type of this preferred identifier, as it may change.
 
+    ## Rate limits
+
+    You can make up to **1,000 requests** (of any type) to Find Case Law in any **rolling five minute period** per IP address. If you have exceeded this, you will receive a `HTTP 429` error code.
+
+    If you need to make more requests, please email [caselaw@nationalarchives.gov.uk](mailto:caselaw@nationalarchives.gov.uk) to talk about your requirements.
+
     ## Give us your feedback
 
     We are still actively developing the Find Case Law service. This includes improving how you can access our data programmatically.
@@ -86,6 +92,8 @@ components:
           summary: A newer document URI
       description: The unique identifier for this document within Find Case Law.
   responses:
+    tooManyRequests:
+      description: Too Many Requests
     documentFeed:
       description: |
         An Atom feed of documents, sorted by one of the dates within those documents.
@@ -252,6 +260,8 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/documentFeed"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
       tags:
         - Document metadata
   "/{document_uri}/data.xml":
@@ -261,6 +271,8 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/document"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
       tags:
         - Document contents
       description: |
@@ -321,6 +333,8 @@ paths:
               schema:
                 type: string
               description: "https://caselaw.nationalarchives.gov.uk/atom.xml?court={court}/{subdivision}&year={year}&order=-date&page=1"
+        "429":
+          $ref: "#/components/responses/tooManyRequests"
       tags:
         - Document metadata
       deprecated: true


### PR DESCRIPTION
We recently added a rate limit of 1,000 requests over five minutes to prevent abuse. Add this fact to the API documentation, which is where people likely to hit the limit will be looking.