### PR TITLE
Update API client package name in Renovate config

### DIFF
--- a/default.json
+++ b/default.json
@@ -27,7 +27,7 @@
     {
       "matchPackageNames": [
         "ds-caselaw-utils",
-        "ds-caselaw-custom-api-client",
+        "ds-caselaw-marklogic-api-client",
         "ds-caselaw-frontend"
       ],
       "minimumReleaseAge": "0 days"


### PR DESCRIPTION
Our API client still appears to be waiting three days before being considered for merge, instead of being automatically included. This is probably down to the package name in pypi being different to the repository name, so fix it.